### PR TITLE
Allow to ignore presentation indicator of outgoing calls [2/3]

### DIFF
--- a/src/java/com/android/internal/telephony/GsmCdmaConnection.java
+++ b/src/java/com/android/internal/telephony/GsmCdmaConnection.java
@@ -24,6 +24,7 @@ import android.os.PersistableBundle;
 import android.os.PowerManager;
 import android.os.Registrant;
 import android.os.SystemClock;
+import android.provider.Settings;
 import android.telephony.CarrierConfigManager;
 import android.telephony.DisconnectCause;
 import android.telephony.Rlog;
@@ -776,7 +777,14 @@ public class GsmCdmaConnection extends Connection {
 
         if (Phone.DEBUG_PHONE) log("--dssds----"+mCnapName);
         mCnapNamePresentation = dc.namePresentation;
-        mNumberPresentation = dc.numberPresentation;
+
+        final Phone phone = mOwner.getPhone();
+        boolean connectedLineIdentification = Settings.Global.getInt(
+                phone.getContext().getContentResolver(),
+                Settings.Global.CONNECTED_LINE_IDENTIFICATION + phone.getSubId(), 1) != 0;
+        if (mIsIncoming || connectedLineIdentification) {
+            mNumberPresentation = dc.numberPresentation;
+        }
 
         if (newParent != mParent) {
             if (mParent != null) {


### PR DESCRIPTION
With some mobile network operators, the presentation indicator of
outgoing calls is always set to either "unknown" or "restricted".
As consequence, the dialed number doesn't show up in clear in the
call history. Allow to ignore the presentation indicator of outgoing
calls to never hide the dialed numbers.

Change-Id: Ifb5a11d3b46e22d7cdc502d447a55b307226ff71