### PR TITLE
Some fixes

### DIFF
--- a/src/java/com/android/internal/telephony/GsmCdmaPhone.java
+++ b/src/java/com/android/internal/telephony/GsmCdmaPhone.java
@@ -3471,8 +3471,10 @@ public class GsmCdmaPhone extends Phone {
             result = mIExtTelephony.isEmergencyNumber(address);
         } catch (RemoteException ex) {
             loge("RemoteException" + ex);
+            result = PhoneNumberUtils.isEmergencyNumber(address);
         } catch (NullPointerException ex) {
             loge("NullPointerException" + ex);
+            result = PhoneNumberUtils.isEmergencyNumber(address);
         }
         return result;
     }

--- a/src/java/com/android/internal/telephony/GsmCdmaPhone.java
+++ b/src/java/com/android/internal/telephony/GsmCdmaPhone.java
@@ -2026,6 +2026,7 @@ public class GsmCdmaPhone extends Phone {
     private void syncClirSetting() {
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(getContext());
         int clirSetting = sp.getInt(CLIR_KEY + getPhoneId(), -1);
+        Rlog.i(LOG_TAG, "syncClirSetting: " + CLIR_KEY + getPhoneId() + "=" + clirSetting);
         if (clirSetting >= 0) {
             mCi.setCLIR(clirSetting, null);
         }

--- a/src/java/com/android/internal/telephony/InboundSmsHandler.java
+++ b/src/java/com/android/internal/telephony/InboundSmsHandler.java
@@ -82,6 +82,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import android.util.EventLog;
 
 /**
  * This class broadcasts incoming SMS messages to interested apps after storing them in
@@ -794,6 +795,19 @@ public abstract class InboundSmsHandler extends StateMachine {
         int destPort = tracker.getDestPort();
         boolean block = false;
 
+        // Do not process when the message count is invalid.
+        if (messageCount <= 0) {
+            EventLog.writeEvent(
+                    0x534e4554 /* snetTagId */,
+                    "72298611" /* buganizer id */,
+                    -1 /* uid */,
+                    String.format(
+                            "processMessagePart: invalid messageCount = %d",
+                            messageCount));
+
+            return false;
+        }
+
         if (messageCount == 1) {
             // single-part message
             pdus = new byte[][]{tracker.getPdu()};
@@ -828,6 +842,21 @@ public abstract class InboundSmsHandler extends StateMachine {
                     // subtract offset to convert sequence to 0-based array index
                     int index = cursor.getInt(PDU_SEQUENCE_PORT_PROJECTION_INDEX_MAPPING
                             .get(SEQUENCE_COLUMN)) - tracker.getIndexOffset();
+
+                    // The invalid PDUs can be received and stored in the raw table. The range
+                    // check ensures the process not crash even if the seqNumber in the
+                    // UserDataHeader is invalid.
+                    if (index >= pdus.length || index < 0) {
+                        EventLog.writeEvent(
+                                0x534e4554 /* snetTagId */,
+                                "72298611" /* buganizer id */,
+                                -1 /* uid */,
+                                String.format(
+                                        "processMessagePart: invalid seqNumber = %d, messageCount = %d",
+                                        index + tracker.getIndexOffset(),
+                                        messageCount));
+                        continue;
+                    }
 
                     pdus[index] = HexDump.hexStringToByteArray(cursor.getString(
                             PDU_SEQUENCE_PORT_PROJECTION_INDEX_MAPPING.get(PDU_COLUMN)));

--- a/src/java/com/android/internal/telephony/Phone.java
+++ b/src/java/com/android/internal/telephony/Phone.java
@@ -1302,6 +1302,8 @@ public abstract class Phone extends Handler implements PhoneInternalInterface {
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(getContext());
         SharedPreferences.Editor editor = sp.edit();
         editor.putInt(CLIR_KEY + getPhoneId(), commandInterfaceCLIRMode);
+        Rlog.i(LOG_TAG, "saveClirSetting: " + CLIR_KEY + getPhoneId() + "=" +
+                commandInterfaceCLIRMode);
 
         // Commit and log the result.
         if (!editor.commit()) {

--- a/src/java/com/android/internal/telephony/SubscriptionController.java
+++ b/src/java/com/android/internal/telephony/SubscriptionController.java
@@ -818,7 +818,7 @@ public class SubscriptionController extends ISub.Stub {
             }
 
             // Reset user choice for defaultSmsSubId in case only one Sim is inserted
-            if (sSlotIdxToSubId.size() == 1) {
+            if (getActiveSubInfoCountMax() == 1) {
                 Rlog.i(LOG_TAG, "Only one SIM found, resetting user preferred SMS sub");
                 mUserPreferredSmsSubId = SubscriptionManager.INVALID_SUBSCRIPTION_ID;
             }

--- a/src/java/com/android/internal/telephony/UiccSmsController.java
+++ b/src/java/com/android/internal/telephony/UiccSmsController.java
@@ -327,7 +327,11 @@ public class UiccSmsController extends ISms.Stub {
             }
         }
 
-        return !canCurrentAppHandleAlwaysAsk;
+        if (telephonyManager.getSimCount() > 1) {
+            return !canCurrentAppHandleAlwaysAsk;
+        }
+
+        return false;
     }
 
     @Override

--- a/src/java/com/android/internal/telephony/imsphone/ImsPhoneCallTracker.java
+++ b/src/java/com/android/internal/telephony/imsphone/ImsPhoneCallTracker.java
@@ -67,6 +67,7 @@ import com.android.ims.internal.IImsVideoCallProvider;
 import com.android.ims.internal.ImsCallSession;
 import com.android.ims.internal.ImsVideoCallProviderWrapper;
 import com.android.ims.internal.VideoPauseTracker;
+import com.android.internal.annotations.VisibleForTesting;
 import com.android.internal.telephony.Call;
 import com.android.internal.telephony.CallStateException;
 import com.android.internal.telephony.CallTracker;
@@ -100,6 +101,10 @@ public class ImsPhoneCallTracker extends CallTracker implements ImsPullCall {
 
     public interface PhoneStateListener {
         void onPhoneStateChanged(PhoneConstants.State oldState, PhoneConstants.State newState);
+    }
+
+    public interface SharedPreferenceProxy {
+        SharedPreferences getDefaultSharedPreferences(Context context);
     }
 
     private static final boolean DBG = true;
@@ -346,6 +351,13 @@ public class ImsPhoneCallTracker extends CallTracker implements ImsPullCall {
      */
     private boolean mShouldUpdateImsConfigOnDisconnect = false;
 
+    /**
+     * Default implementation for retrieving shared preferences; uses the actual PreferencesManager.
+     */
+    private SharedPreferenceProxy mSharedPreferenceProxy = (Context context) -> {
+        return PreferenceManager.getDefaultSharedPreferences(context);
+    };
+
     //***** Events
 
 
@@ -369,6 +381,16 @@ public class ImsPhoneCallTracker extends CallTracker implements ImsPullCall {
         // Send a message to connect to the Ims Service and open a connection through
         // getImsService().
         sendEmptyMessage(EVENT_GET_IMS_SERVICE);
+    }
+
+    /**
+     * Test-only method used to mock out access to the shared preferences through the
+     * {@link PreferenceManager}.
+     * @param sharedPreferenceProxy
+     */
+    @VisibleForTesting
+    public void setSharedPreferenceProxy(SharedPreferenceProxy sharedPreferenceProxy) {
+        mSharedPreferenceProxy = sharedPreferenceProxy;
     }
 
     private PendingIntent createIncomingCallPendingIntent() {
@@ -451,8 +473,16 @@ public class ImsPhoneCallTracker extends CallTracker implements ImsPullCall {
 
     public Connection dial(String dialString, int videoState, Bundle intentExtras) throws
             CallStateException {
-        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(mPhone.getContext());
-        int oirMode = sp.getInt(Phone.CLIR_KEY, CommandsInterface.CLIR_DEFAULT);
+        int oirMode;
+        if (mSharedPreferenceProxy != null && mPhone.getDefaultPhone() != null) {
+            SharedPreferences sp = mSharedPreferenceProxy.getDefaultSharedPreferences(
+                    mPhone.getContext());
+            oirMode = sp.getInt(Phone.CLIR_KEY + mPhone.getDefaultPhone().getPhoneId(),
+                    CommandsInterface.CLIR_DEFAULT);
+        } else {
+            loge("dial; could not get default CLIR mode.");
+            oirMode = CommandsInterface.CLIR_DEFAULT;
+        }
         return dial(dialString, oirMode, videoState, intentExtras);
     }
 

--- a/tests/telephonytests/src/com/android/internal/telephony/imsphone/ImsPhoneCallTrackerTest.java
+++ b/tests/telephonytests/src/com/android/internal/telephony/imsphone/ImsPhoneCallTrackerTest.java
@@ -16,11 +16,13 @@
 package com.android.internal.telephony.imsphone;
 
 import android.app.PendingIntent;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.HandlerThread;
 import android.os.Message;
+import android.telecom.VideoProfile;
 import android.telephony.PhoneNumberUtils;
 import android.test.suitebuilder.annotation.SmallTest;
 


### PR DESCRIPTION
### GsmCdmaPhone: Fallback to PhoneNumberUtils if telephony-ext fails

* Fixes emergency calls when SIM card isn't present

Change-Id: If6dfb4468b4a26abbe6e0e5a687b7fb44a70f369

### Ensure IMS dial uses the correct CLIR mode.

The IMS dial method was getting the shared pref CLIR_KEY to determine the
CLIR mode for an outgoing call.  Everywhere else in the code, the CLIR
mode is stored under key CLIR_KEY + phoneId, against the phoneId of the
Gsm/Cdma phone.
In ImsPhoneCallTracker, the default phone for the ImsPhone is the Gsm/Cdma
phone, and we need to use that id when accessing the key.
Also, added some more logging for oir mode sync/save.

Test: Manual
Bug: 64291602
Merged-In: I231f8fb74c29347da2085318b9ca42d5efec5271
Change-Id: I231f8fb74c29347da2085318b9ca42d5efec5271
(cherry picked from commit fc13875)

### Don't show sim pick activity if device is single SIM

* The activity is triggered when the default SMS app isn't com.android.messaging 
  without checking if the device is single SIM or not

Change-Id: I6ccc1338a97a11ea6e7ea232519e0d768bbb954d

### ImsPhoneCallTrackerTest: add missing imports

Change-Id: I94fc8f6dc923086a2b229eb0bc2f5f43a20aa35e

### Telephony: Fix "Keep preferred SMS Sim"

* Instead of checking the size of an array which is still populating (and
  on registering the first sim will obviously return a size of 1), check
  the actual sim count before resetting the user preference
* This fixes the problem that the default SIM for SMS is set to sim1 after
  each reboot

Change-Id: Ia065f2dbbd9d1b824c921fd5d2052b5eb6313aff

### Fixed invalid pdu issue

The device may receive invalid sms pdu, i.e the pdu contins sms header
with an invalid seqNumber. This caused InboundSmsHandler crashed constantly.
This CL added the range check for the seqNumber to ensure the
InboundSmsHandler will not crash even if the seqNumber is invalid.

Test: runtest -x GsmInboundSmsHandlerTest -m
testMultiPartSmsWithInvalidSeqNumber
Bug: 72298611

Merged-In: Icf291c8530abdc2a528c5cf227cf00135281b899
Change-Id: Icf291c8530abdc2a528c5cf227cf00135281b899
(cherry picked from commit 9eec9d02937dd41fc94ad1c874f8467f4698df5c)
(cherry picked from commit d2f410c)
(cherry picked from commit e895527)
CVE-2018-9362